### PR TITLE
Added live endpoint tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ tokio = { version = "1.37.0", features = ["full"] }
 gtfs-structures = "0.41.2"
 geojson = "0.24.1"
 lazy_static = "1.4.0"
+serde_path_to_error = "0.1.16"
 
 [[example]]
 name = "client_example"

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -32,6 +32,30 @@ impl<'a> de::Visitor<'a> for CsvEncodedStringVisitor {
     }
 }
 
+pub fn deserialize_option_csv_encoded_string<'a, D: de::Deserializer<'a>>(
+    deserializer: D,
+) -> Result<Option<Vec<i32>>, D::Error> {
+    deserializer.deserialize_option(OptionCsvEncodedStringVisitor)
+}
+
+struct OptionCsvEncodedStringVisitor;
+
+impl<'a> de::Visitor<'a> for OptionCsvEncodedStringVisitor {
+    type Value = Option<Vec<i32>>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "a string of comma-separated integers or null")
+    }
+
+    fn visit_none<E: de::Error>(self) -> Result<Self::Value, E> {
+        Ok(None)
+    }
+
+    fn visit_some<D: de::Deserializer<'a>>(self, d: D) -> Result<Self::Value, D::Error> {
+        Ok(Some(d.deserialize_str(CsvEncodedStringVisitor)?))
+    }
+}
+
 pub fn deserialize_optional_string_enum<'a, D: de::Deserializer<'a>, T: FromStr + 'a>(
     deserializer: D,
 ) -> Result<Option<T>, D::Error> {

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -4,10 +4,10 @@ use std::{collections::HashMap, convert::TryFrom};
 
 use crate::{
     deserialize::{
-        deserialize_api_error, deserialize_bool, deserialize_csv_encoded_string, deserialize_f64,
-        deserialize_naive_date_time, deserialize_naive_time, deserialize_naive_time_with_space,
-        deserialize_option_naive_time_with_space, deserialize_optional_f64,
-        deserialize_optional_string_enum, deserialize_string_enum,
+        deserialize_api_error, deserialize_bool, deserialize_f64, deserialize_naive_date_time,
+        deserialize_naive_time, deserialize_naive_time_with_space,
+        deserialize_option_csv_encoded_string, deserialize_option_naive_time_with_space,
+        deserialize_optional_f64, deserialize_optional_string_enum, deserialize_string_enum,
     },
     types::{RegionalRailStop, RegionalRailsLine, ServiceType},
 };
@@ -148,8 +148,8 @@ pub struct Train {
     #[serde(deserialize_with = "deserialize_string_enum")]
     pub line: RegionalRailsLine,
 
-    #[serde(deserialize_with = "deserialize_csv_encoded_string")]
-    pub consist: Vec<i32>,
+    #[serde(deserialize_with = "deserialize_option_csv_encoded_string")]
+    pub consist: Option<Vec<i32>>,
 
     #[serde(deserialize_with = "deserialize_optional_f64")]
     pub heading: Option<f64>,

--- a/tests/live_endpoint_canary.rs
+++ b/tests/live_endpoint_canary.rs
@@ -1,0 +1,153 @@
+//! This file contains tests that hit the live SEPTA API endpoints and deserialize the responses.
+//! They operate the same way as production code with the exception that they are run using the
+//! `serde_path_to_error` crate so that if deserialization fails, the path to the error is printed
+//! to the console, making is easier to figure out where the offending data is located. I wish that
+//! API responses had consistent types, but it seems that SEPTA's API is inconsistent since it is
+//! most likely programmed in Python, PHP or some other God-forsaken language that doesn't have
+//! static types.
+use reqwest::Client;
+use septa_api::{
+    requests::{self, Request},
+    responses,
+    types::RegionalRailStop,
+};
+
+const BASE_API_URL: &str = "https://www3.septa.org/api";
+
+#[tokio::test]
+async fn test_live_arrivals_endpoint() -> Result<(), Box<dyn std::error::Error>> {
+    const ENDPOINT: &str = "/Arrivals/index.php";
+
+    let request = requests::ArrivalsRequest {
+        station: RegionalRailStop::SuburbanStation,
+        results: Some(10),
+        direction: None,
+    };
+
+    let bytes = Client::new()
+        .get(format!("{}{}", BASE_API_URL, ENDPOINT))
+        .query(&request.into_params())
+        .send()
+        .await?
+        .bytes()
+        .await?;
+
+    let deserialized = &mut serde_json::Deserializer::from_slice(bytes.as_ref());
+
+    let result: Result<responses::ArrivalsResponse, _> =
+        serde_path_to_error::deserialize(deserialized);
+
+    if let Err(err) = result {
+        let path = err.path().to_string();
+        panic!(
+            "Error deserializing ArrivalsResponse: {}: {}",
+            path,
+            std::str::from_utf8(bytes.as_ref()).unwrap_or("Failed to convert bytes to string")
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_live_train_view_endpoint() -> Result<(), Box<dyn std::error::Error>> {
+    const ENDPOINT: &str = "/TrainView/index.php";
+
+    let bytes = Client::new()
+        .get(format!("{}{}", BASE_API_URL, ENDPOINT))
+        .send()
+        .await?
+        .bytes()
+        .await?;
+
+    let deserialized = &mut serde_json::Deserializer::from_slice(bytes.as_ref());
+
+    let result: Result<responses::TrainResponse, _> =
+        serde_path_to_error::deserialize(deserialized);
+
+    if let Err(err) = result {
+        let path = err.path().to_string();
+        panic!(
+            "Error deserializing TrainResponse: {}: {}",
+            path,
+            std::str::from_utf8(bytes.as_ref()).unwrap_or("Failed to convert bytes to string")
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_live_next_to_arrive_endpoint() -> Result<(), Box<dyn std::error::Error>> {
+    const ENDPOINT: &str = "/NextToArrive/index.php";
+
+    let request = requests::NextToArriveRequest {
+        starting_station: RegionalRailStop::SuburbanStation,
+        ending_station: RegionalRailStop::Paoli,
+        results: None,
+    };
+
+    let bytes = Client::new()
+        .get(format!("{}{}", BASE_API_URL, ENDPOINT))
+        .query(&request.into_params())
+        .send()
+        .await?
+        .bytes()
+        .await?;
+
+    let deserialized = &mut serde_json::Deserializer::from_slice(bytes.as_ref());
+
+    let result: Result<responses::NextToArriveResponse, _> =
+        serde_path_to_error::deserialize(deserialized);
+
+    if let Err(err) = result {
+        let path = err.path().to_string();
+        panic!(
+            "Error deserializing NextToArriveResponse: {}: {}",
+            path,
+            std::str::from_utf8(bytes.as_ref()).unwrap_or("Failed to convert bytes to string")
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_live_rail_schedule_endpoint() -> Result<(), Box<dyn std::error::Error>> {
+    const ENDPOINT: &str = "/RRSchedules/index.php";
+
+    let request = requests::RailScheduleRequest {
+        train_number: "514".to_string(),
+    };
+
+    let bytes = Client::new()
+        .get(format!("{}{}", BASE_API_URL, ENDPOINT))
+        .query(&request.into_params())
+        .send()
+        .await?
+        .bytes()
+        .await?;
+
+    let deserialized = &mut serde_json::Deserializer::from_slice(bytes.as_ref());
+
+    let result: Result<responses::RailScheduleResponse, _> =
+        serde_path_to_error::deserialize(deserialized);
+
+    match result {
+        Ok(schedule) => {
+            if schedule.is_empty() {
+                panic!("Expected at least one schedule entry, found none");
+            }
+        }
+        Err(err) => {
+            let path = err.path().to_string();
+            panic!(
+                "Error deserializing RailScheduleResponse: {}: {}",
+                path,
+                std::str::from_utf8(bytes.as_ref()).unwrap_or("Failed to convert bytes to string")
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/tests/train_view.rs
+++ b/tests/train_view.rs
@@ -79,7 +79,7 @@ async fn test_deserialize1_async() -> Result<(), septa_api::errors::Error> {
     assert_eq!(trains[0].dest, RegionalRailStop::Wawa);
     assert_eq!(trains[0].current_stop, RegionalRailStop::SuburbanStation);
     assert_eq!(trains[0].next_stop, RegionalRailStop::Gray30thStreet);
-    assert_eq!(trains[0].consist, vec![872, 871, 858, 857]);
+    assert_eq!(trains[0].consist, Some(vec![872, 871, 858, 857]));
     assert_eq!(trains[0].heading, Some(189.8775840187919));
     assert_eq!(trains[0].late, 0);
     assert_eq!(trains[0].source, RegionalRailStop::NorristownTC);
@@ -93,7 +93,7 @@ async fn test_deserialize1_async() -> Result<(), septa_api::errors::Error> {
     assert_eq!(trains[1].dest, RegionalRailStop::Lansdale);
     assert_eq!(trains[1].current_stop, RegionalRailStop::GwyneddValley);
     assert_eq!(trains[1].next_stop, RegionalRailStop::NorthWales);
-    assert_eq!(trains[1].consist, vec![415, 366, 367, 126, 125]);
+    assert_eq!(trains[1].consist, Some(vec![415, 366, 367, 126, 125]));
     assert_eq!(trains[1].heading, Some(326.98421204774684));
     assert_eq!(trains[1].late, 0);
     assert_eq!(trains[1].source, RegionalRailStop::Newark);
@@ -107,7 +107,7 @@ async fn test_deserialize1_async() -> Result<(), septa_api::errors::Error> {
     assert_eq!(trains[2].dest, RegionalRailStop::NorristownTC);
     assert_eq!(trains[2].current_stop, RegionalRailStop::SuburbanStation);
     assert_eq!(trains[2].next_stop, RegionalRailStop::JeffersonStation);
-    assert_eq!(trains[2].consist, vec![705, 716, 861, 862]);
+    assert_eq!(trains[2].consist, Some(vec![705, 716, 861, 862]));
     assert_eq!(trains[2].heading, Some(101.50453615740082));
     assert_eq!(trains[2].late, 0);
     assert_eq!(trains[2].source, RegionalRailStop::Wawa);
@@ -142,7 +142,7 @@ async fn test_deserialize1_async() -> Result<(), septa_api::errors::Error> {
 //     assert_eq!(trains[0].current_stop, RegionalRailStop::SuburbanStation);
 //     assert_eq!(trains[0].next_stop, RegionalRailStop::Gray30thStreet);
 //     assert_eq!(trains[0].line, RegionalRailsLine::Cynwyd);
-//     assert_eq!(trains[0].consist, vec![721]);
+//     assert_eq!(trains[0].consist, Some(vec![721]));
 //     assert_eq!(trains[0].heading, Some(279.74492662582446));
 //     assert_eq!(trains[0].late, 0);
 //     assert_eq!(trains[0].source, RegionalRailStop::SuburbanStation);


### PR DESCRIPTION
Added a test for each of the endpoints. These tests have use the serde_path_to_error crate so that if there is a failure we can detect which field is causing the deserialization error.