### PR TITLE
Added Rush Hour Live CI Test

### DIFF
--- a/.github/workflows/live-endpoint.yml
+++ b/.github/workflows/live-endpoint.yml
@@ -1,0 +1,29 @@
+name: Live Endpoint Test
+
+on:
+  schedule:
+    - cron: "30 13 * * *" # Run at 8:30 AM EST (Morning Rush Hour)
+    - cron: "15 22 * * *" # Run at 5:15 PM EST (Evening Rust Hour)
+
+jobs:
+  live-endpoint:
+    name: Live Endpoint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v4
+        with:
+          lfs: false
+
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Display Toolchain Information
+        run: |
+          cargo --version --verbose
+          rustc --version
+
+      - name: Live Endpoint Test
+        run: |
+          cargo check
+          cargo test --verbose --tests live_endpoint_canary


### PR DESCRIPTION
Added the the live endpoint test as a Github CI. This will trigger during rush hour to ensure we get most of the trains in route to ensure that we are stressing the deserializer.