### PR TITLE
Fixup the Cargo file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/StefanBossbaly/septa-api/"
 authors = ["Stefan Bossbaly <sbossb@gmail.com>"]
 license = "MIT"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+include = ["/src/**/*.rs", "/README.md", "/LICENSE"]
 
 [dependencies]
 chrono = "0.4.38"
@@ -21,7 +21,7 @@ thiserror = "1.0.61"
 
 [dev-dependencies]
 mockito = "1.4.0"
-tokio = { version = "1.37.0", features = ["full"] }
+tokio = { version = "1.38.0", features = ["macros", "rt-multi-thread"] }
 gtfs-structures = "0.41.3"
 geojson = "0.24.1"
 once_cell = "1.19.0"


### PR DESCRIPTION
Added include parameter to only include the files need for build. Also update tokio to 1.38 and only use the needed features.